### PR TITLE
chunk size precautions

### DIFF
--- a/src/semchunk/semchunk.py
+++ b/src/semchunk/semchunk.py
@@ -457,6 +457,52 @@ def chunkerify(
                 "Your desired chunk size was not passed to `semchunk.chunkerify` and the provided tokenizer either lacks an attribute named 'model_max_length' or that attribute is not an integer. Either specify a chunk size or provide a tokenizer that has a 'model_max_length' attribute that is an integer."
             )
 
+
+    # PROPOSAL 1: Warning-only approach - Warns the user but allows processing to continue if chunk_size exceeds model's limit
+    # if hasattr(tokenizer_or_token_counter, "model_max_length"):
+    #     model_max = tokenizer_or_token_counter.model_max_length
+    #     # Adjust model_max by subtracting special token overhead if possible
+    #     if hasattr(tokenizer_or_token_counter, "encode"):
+    #         with suppress(Exception):
+    #             model_max -= len(tokenizer_or_token_counter.encode(""))
+    #     # Issue warning if chunk_size exceeds adjusted model maximum
+    #     if chunk_size > model_max:
+    #         import warnings
+    #         warnings.warn(
+    #             f"Specified chunk_size ({chunk_size}) exceeds model's maximum sequence length ({model_max}). "
+    #             "This may result in truncation or indexing errors."
+    #         )
+
+    # PROPOSAL 2: Error-raising approach - Prevents processing entirely if chunk_size exceeds model's limit
+    # if hasattr(tokenizer_or_token_counter, "model_max_length"):
+    #     model_max = tokenizer_or_token_counter.model_max_length
+    #     # Adjust model_max by subtracting special token overhead if possible
+    #     if hasattr(tokenizer_or_token_counter, "encode"):
+    #         with suppress(Exception):
+    #             model_max -= len(tokenizer_or_token_counter.encode(""))
+    #     # Raise error if chunk_size exceeds adjusted model maximum
+    #     if chunk_size > model_max:
+    #         raise ValueError(
+    #             f"Specified chunk_size ({chunk_size}) exceeds model's maximum sequence length ({model_max}). "
+    #             f"Please specify a chunk_size <= {model_max}."
+    #         )
+
+    # PROPOSAL 3: Auto-capping approach - Automatically adjusts chunk_size to model's limit with warning
+    # if hasattr(tokenizer_or_token_counter, "model_max_length"):
+    #     model_max = tokenizer_or_token_counter.model_max_length
+    #     # Adjust model_max by subtracting special token overhead if possible
+    #     if hasattr(tokenizer_or_token_counter, "encode"):
+    #         with suppress(Exception):
+    #             model_max -= len(tokenizer_or_token_counter.encode(""))
+    #     # If chunk_size exceeds model maximum, cap it at model maximum and warn user
+    #     if chunk_size > model_max:
+    #         import warnings
+    #         warnings.warn(
+    #             f"Specified chunk_size ({chunk_size}) exceeds model's maximum sequence length ({model_max}). "
+    #             f"Using maximum allowed size of {model_max} instead."
+    #         )
+    #         chunk_size = model_max
+
     # If we have been given a tokenizer, construct a token counter from it.
     if hasattr(tokenizer_or_token_counter, "encode"):
         # Determine whether the tokenizer accepts the argument `add_special_tokens` and, if so, ensure that it is always disabled.


### PR DESCRIPTION
I had fun learning about your library and thought I might contribute.  When investigating the message I kept getting that stated `Token indices sequence length is longer than the specified maximum sequence length for this model (676 > 512). Running this sequence through the model will result in indexing errors` I discovered that it originated from the `Transformers` library but that it's normal insofar as ```semchunk``` tries to optimize the ultimate chunks, to put it simplistically.

Upon further research, I discovered that the `chunk_size` parameter is repeatedly consulted in order to respect that limit, but I didn't see where the tokenizer's inherent limit was consult in the same way.  In theory, a user could specify a `chunk_size` larger than the tokenizer's inherent limit.  True, they'd "probably" get the aforementioned print statement provided they haven't turned off the logger/warning or what not, but I thought it'd be nice to add some handling within `semchunk` itself.

I've commented out three proposals and added explanations within them.  One came be commented out and used or they can be a source of further discussion.